### PR TITLE
fix: add shebang to CLI entry point

### DIFF
--- a/cli/src/bin.ts
+++ b/cli/src/bin.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { render } from "ink";
 import React from "react";
 import { App } from "./app.js";


### PR DESCRIPTION
Fixes #2

Adds the required shebang line (`#!/usr/bin/env node`) to `cli/src/bin.ts` to fix the issue where the Opal command opens a text editor instead of executing.

## Root Cause
Without the shebang, npm doesn't recognize the file as a Node.js executable and won't create proper platform-specific wrapper scripts during installation.

## Solution
The shebang ensures that:
- On Unix-like systems, the file is executed with Node.js
- On Windows, npm creates proper .cmd and .ps1 wrapper scripts
- The file is recognized as an executable script

Generated with [Claude Code](https://claude.ai/code)