### PR TITLE
feat(ci): add agent skills and session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# --- Elixir / Erlang via asdf (read versions from .tool-versions) ---
+if ! command -v mix &>/dev/null; then
+  # Install asdf if missing
+  if ! command -v asdf &>/dev/null; then
+    git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.16.7 2>/dev/null || true
+    # shellcheck source=/dev/null
+    . "$HOME/.asdf/asdf.sh"
+  fi
+
+  asdf plugin add erlang 2>/dev/null || true
+  asdf plugin add elixir 2>/dev/null || true
+  asdf install erlang
+  asdf install elixir
+fi
+
+# Ensure asdf shims are on PATH for subsequent commands
+if [ -f "$HOME/.asdf/asdf.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.asdf/asdf.sh"
+fi
+
+# --- Node.js dependencies (pnpm monorepo: root + cli workspace) ---
+pnpm install
+
+# --- Elixir dependencies ---
+cd core
+mix local.hex --force --if-missing
+mix deps.get
+mix compile
+cd ..

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/ci-preflight/SKILL.md
+++ b/.claude/skills/ci-preflight/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ci-preflight
+description: Runs the full CI check suite locally before pushing. Use this skill before pushing a branch or when the user asks to verify everything passes, to catch issues before they hit CI.
+globs: "**/*"
+---
+
+# CI Preflight Skill
+
+You run the same checks that GitHub Actions CI performs, but locally, to catch failures before pushing. This saves time and keeps the commit history clean.
+
+## When to act
+
+- Before pushing a branch to remote.
+- When the user asks to "run CI", "check everything", or "preflight".
+- After a large set of changes to verify nothing is broken.
+
+## Check sequence
+
+Run these in order. Stop and fix issues at each step before proceeding.
+
+### 1. Elixir core
+
+```bash
+# Compile with warnings-as-errors (matches CI)
+pnpm nx run core:build
+
+# Check formatting
+pnpm nx run core:lint
+
+# Run tests
+pnpm nx run core:test
+```
+
+### 2. TypeScript CLI
+
+```bash
+# Lint (ESLint)
+pnpm nx run cli:lint
+
+# Verify codegen is current
+pnpm nx run cli:codegen:check
+
+# Build (typecheck + compile)
+pnpm nx run cli:build
+```
+
+### 3. Quick summary
+
+Or run everything at once:
+
+```bash
+pnpm lint && pnpm build && pnpm test
+```
+
+## Rules
+
+1. **Every check must pass before pushing.** If something fails, fix it first.
+2. Report results clearly — list what passed and what failed.
+3. For failures, diagnose the root cause and suggest or apply fixes.
+4. If a test is flaky (passes on retry), flag it to the user rather than silently retrying.

--- a/.claude/skills/codegen-sync/SKILL.md
+++ b/.claude/skills/codegen-sync/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: codegen-sync
+description: Verifies TypeScript codegen is in sync with Elixir protocol definitions. Use this skill after modifying Elixir structs, protocol messages, or RPC types in core/ to regenerate and verify the TypeScript client SDK types.
+globs: "{core/lib/opal/rpc/**,core/lib/opal/agent/**,cli/src/sdk/**}"
+---
+
+# Codegen Sync Skill
+
+This project uses code generation to keep TypeScript SDK types in sync with Elixir protocol definitions. When Elixir types change, the TypeScript side must be regenerated.
+
+## When to act
+
+- After modifying any Elixir structs, message types, or RPC definitions in `core/`.
+- After adding or changing tool schemas in `core/lib/opal/tool/`.
+- When CI fails with a codegen drift error.
+- When the user asks to sync or regenerate types.
+
+## Commands
+
+```bash
+# Run codegen (Elixir -> TypeScript)
+pnpm codegen
+
+# Verify codegen is up to date (what CI runs)
+pnpm nx run cli:codegen:check
+```
+
+## Workflow
+
+1. After modifying Elixir protocol types, run `pnpm codegen`.
+2. Review the generated diff in `cli/src/sdk/` to verify correctness.
+3. Include the regenerated files in the same commit as the Elixir changes.
+
+## Rules
+
+1. **Never hand-edit generated files.** Always regenerate from the Elixir source.
+2. If codegen output looks wrong, fix the Elixir definitions or the codegen script (`scripts/codegen_ts.exs`), not the output.
+3. Always commit codegen output alongside the source changes — never in a separate commit.

--- a/.claude/skills/git/SKILL.md
+++ b/.claude/skills/git/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: git
+description: Enforces conventional commit messages and good git hygiene. Use this skill automatically whenever creating commits, preparing PRs, or performing any git operations in this repository.
+globs: "**/*"
+---
+
+# Git Conventional Commit Skill
+
+You enforce [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) on every commit in this repository. This is critical because the project uses `nx release` with `conventionalCommits: true` to auto-generate changelogs and determine semantic version bumps.
+
+## Commit message format
+
+Every commit message MUST follow this format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types (required)
+
+| Type       | When to use                                      | Version bump |
+|------------|--------------------------------------------------|-------------|
+| `feat`     | A new feature or capability                      | minor       |
+| `fix`      | A bug fix                                        | patch       |
+| `docs`     | Documentation only                               | none        |
+| `style`    | Formatting, semicolons, whitespace — no logic    | none        |
+| `refactor` | Code change that neither fixes a bug nor adds a feature | none  |
+| `perf`     | Performance improvement                          | patch       |
+| `test`     | Adding or correcting tests                       | none        |
+| `build`    | Build system or external dependency changes      | none        |
+| `ci`       | CI configuration changes                         | none        |
+| `chore`    | Maintenance tasks (deps, tooling, releases)      | none        |
+
+### Scopes (recommended)
+
+Use a scope to identify the affected area:
+
+| Scope    | Meaning                                     |
+|----------|---------------------------------------------|
+| `core`   | Elixir core (`core/` directory)             |
+| `cli`    | TypeScript CLI (`cli/` directory)           |
+| `rpc`    | JSON-RPC protocol layer                     |
+| `agent`  | Agent loop / GenServer                      |
+| `tools`  | Built-in tool implementations               |
+| `mcp`    | MCP bridge                                  |
+| `ci`     | GitHub Actions workflows                    |
+| `release`| Release and versioning infrastructure       |
+| `docs`   | Documentation                               |
+| `sdk`    | TypeScript SDK client                       |
+
+Omit the scope only when the change truly spans the entire project.
+
+### Breaking changes
+
+Append `!` after the type/scope for breaking changes:
+
+```
+feat(rpc)!: change message envelope format
+```
+
+Or add a `BREAKING CHANGE:` footer in the body.
+
+## Rules
+
+1. **Always** use conventional commit format. Never commit with a bare message like "fix stuff" or "updates".
+2. **Description** must be lowercase, imperative mood, no period at the end.
+3. **Scope** should match the table above when the change is localized.
+4. **Body** is optional but encouraged for non-trivial changes — explain *why*, not *what*.
+5. **One logical change per commit.** Don't bundle unrelated changes.
+6. Before committing, verify the message parses as a valid conventional commit.
+
+## Examples
+
+```
+feat(cli): add --json flag for machine-readable output
+fix(core): prevent crash when tool returns empty response
+docs(tools): document edit tool hashline format
+refactor(agent): extract token counting into dedicated module
+ci: add Elixir dialyzer step to CI pipeline
+chore(release): 0.1.10
+feat(rpc)!: switch from JSON-RPC 2.0 to msgpack framing
+
+BREAKING CHANGE: RPC wire format changed from JSON to msgpack.
+Clients must update to sdk >= 0.2.0.
+```

--- a/.claude/skills/lint-and-format/SKILL.md
+++ b/.claude/skills/lint-and-format/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: lint-and-format
+description: Runs linting and formatting checks before committing. Use this skill after writing or modifying code to ensure it passes all linters and formatters before creating a commit.
+globs: "{core,cli}/**/*.{ex,exs,ts,tsx,js,json}"
+---
+
+# Lint & Format Skill
+
+You ensure all code passes the project's linters and formatters before it gets committed. This mirrors the lefthook pre-commit hooks and CI checks so problems are caught immediately.
+
+## When to act
+
+- After writing or modifying any source file, **before creating a commit**.
+- When the user asks to fix lint or formatting issues.
+- When a commit or CI fails due to formatting.
+
+## Commands
+
+### Elixir (core/)
+
+```bash
+# Check formatting (what CI runs)
+pnpm nx run core:lint
+
+# Auto-fix formatting
+pnpm nx run core:format
+```
+
+### TypeScript/JavaScript (cli/)
+
+```bash
+# ESLint check
+pnpm nx run cli:lint
+
+# ESLint auto-fix
+pnpm nx run cli:lint:fix
+
+# Prettier check
+pnpm nx run cli:format:check
+
+# Prettier auto-fix
+pnpm nx run cli:format
+```
+
+### Run everything
+
+```bash
+# Check all (what CI runs)
+pnpm lint
+
+# Fix all
+pnpm format
+```
+
+## Workflow
+
+1. After making code changes, run the relevant lint/format check commands.
+2. If there are failures, auto-fix them using the fix variants.
+3. If auto-fix changes files, review the diff to make sure nothing unexpected changed.
+4. Only then proceed with staging and committing.
+
+## Rules
+
+1. **Never commit code that fails linting or formatting checks.**
+2. Prefer auto-fix (`pnpm format`, `lint:fix`) over manual edits when possible.
+3. If a lint rule seems wrong for a specific case, discuss with the user before adding a suppression comment.
+4. Do not disable or weaken lint rules without explicit approval.

--- a/.claude/skills/live-tests/SKILL.md
+++ b/.claude/skills/live-tests/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: live-tests
+description: Writes live integration tests that hit the real Copilot API and record responses as replayable fixtures. Use this skill when adding new agent behaviors, provider integrations, or tool interactions that need real-world API coverage.
+globs: "{core/test/**,core/test/support/fixtures/**}"
+---
+
+# Live Test & Fixture Recording Skill
+
+You write live integration tests that exercise the real GitHub Copilot API and capture responses as JSON fixtures for deterministic replay. This is the project's VCR-like system for ensuring tests stay grounded in real API behavior.
+
+## Architecture overview
+
+```
+Live test (mix test --include live --include save_fixtures)
+  │
+  ├─ RecordingProvider  ← wraps real Copilot provider, captures SSE events
+  │     │
+  │     └─ persistent_term storage ← events buffered here during stream
+  │
+  └─ FixtureHelper.save_fixture/2  ← writes events to JSON file
+        │
+        └─ core/test/support/fixtures/<name>.json
+
+Fixture-based test (mix test)
+  │
+  ├─ FixtureProvider  ← reads fixture JSON, replays events via Req.Response.Async
+  │     │
+  │     └─ FixtureHelper.build_fixture_response/1 ← spawns process to send SSE events
+  │
+  └─ Assertions on agent behavior, events, tool calls, etc.
+```
+
+## When to act
+
+- Adding a new agent behavior that needs a new fixture (e.g., new tool call pattern, multi-turn conversation, error handling).
+- Adding or changing provider integration logic.
+- When the user asks to "record a fixture", "add a live test", or "capture API responses".
+- When an existing fixture is stale and needs re-recording.
+
+## Writing a live test
+
+Live tests go in `core/test/opal/live_test.exs`. They require `@moduletag :live` (excluded by default) and use the `RecordingProvider` to capture real SSE events.
+
+### Template
+
+```elixir
+describe "live API — <scenario description>" do
+  @tag :save_fixtures
+  @tag timeout: 30_000
+  test "records <what this captures>" do
+    RecordingProvider.start_recording()
+
+    {:ok, pid} =
+      Opal.start_session(%{
+        model: {:copilot, "claude-sonnet-4"},
+        system_prompt: "<constrained prompt that produces deterministic output>",
+        tools: [<tool modules if needed>],
+        working_dir: System.tmp_dir!(),
+        provider: RecordingProvider
+      })
+
+    {:ok, response} = Opal.prompt_sync(pid, "<user message>", 25_000)
+    Opal.stop_session(pid)
+
+    events = RecordingProvider.stop_recording()
+    assert length(events) > 0
+
+    # Save as a fixture for replay
+    path = FixtureHelper.save_fixture("<descriptive_name>.json", events)
+    assert File.exists?(path)
+
+    # Assertions on the live response
+    assert is_binary(response)
+    assert String.contains?(response, "<expected content>")
+  end
+end
+```
+
+### Running
+
+```bash
+# Run all live tests (requires valid Copilot auth)
+mix test --include live
+
+# Run live tests AND save recorded fixtures to disk
+mix test --include live --include save_fixtures
+
+# Run a specific live test
+mix test --include live test/opal/live_test.exs:<line_number>
+```
+
+## Writing a fixture-based integration test
+
+Once you have a fixture, write a deterministic integration test that replays it. These go in `core/test/opal/integration_test.exs` or a new file under `core/test/opal/`.
+
+### Template
+
+```elixir
+describe "<feature under test>" do
+  test "<what it verifies>" do
+    # Configure the FixtureProvider with your fixture
+    :persistent_term.put({FixtureProvider, :fixture}, "<your_fixture>.json")
+
+    # For multi-turn tests (tool call → second response):
+    # :persistent_term.put({FixtureProvider, :second_fixture}, "<second_turn>.json")
+
+    session_id = "test-#{System.unique_integer([:positive])}"
+    {:ok, tool_sup} = Task.Supervisor.start_link()
+
+    agent_opts = [
+      session_id: session_id,
+      model: Model.new(:copilot, "test-model"),
+      system_prompt: "<system prompt>",
+      tools: [<tool modules>],
+      working_dir: System.tmp_dir!(),
+      provider: FixtureProvider,
+      tool_supervisor: tool_sup
+    ]
+
+    {:ok, pid} = Agent.start_link(agent_opts)
+    Events.subscribe(session_id)
+
+    Agent.prompt(pid, "<user message>")
+
+    # Assert on events received
+    assert_receive {:event, %{type: :response_start}}, 5_000
+    assert_receive {:event, %{type: :text_delta, data: %{delta: delta}}}, 5_000
+    assert is_binary(delta)
+    assert_receive {:event, %{type: :response_end}}, 5_000
+  end
+end
+```
+
+## Fixture file format
+
+Fixtures live in `core/test/support/fixtures/` as JSON:
+
+```json
+{
+  "description": "Recorded live fixture: responses_api_text.json",
+  "recorded_at": "2025-02-13T...",
+  "events": [
+    {"data": "{\"type\":\"response.created\",\"response\":{...}}"},
+    {"data": "{\"type\":\"response.output_item.added\",...}"},
+    {"data": "{\"type\":\"response.completed\",...}"}
+  ]
+}
+```
+
+Each `data` field contains one SSE event payload as a JSON string.
+
+## Rules
+
+1. **System prompts in live tests must be highly constrained** to produce deterministic output. Use prompts like "Respond with exactly the word 'pong'" rather than open-ended prompts.
+2. **Name fixtures descriptively**: `responses_api_tool_call.json`, not `test1.json`.
+3. **Never hand-edit fixture JSON.** Always re-record from a live test.
+4. **Tag live tests correctly**: `@moduletag :live` on the module, `@tag :save_fixtures` on recording tests, `@tag timeout: 30_000` for API calls.
+5. **Clean up after recording tests** if the fixture is only meant for one-time capture — or keep it permanently if it will be used by replay tests.
+6. **Fixture-based tests should be fast and async-safe** — they replay from disk, no network needed.
+7. When adding a fixture for a new scenario (e.g., error response, high token usage), also add a corresponding integration test that replays it.
+
+## Key files
+
+- `core/test/opal/live_test.exs` — Live API tests with recording
+- `core/test/opal/integration_test.exs` — Fixture-based integration tests
+- `core/test/support/fixture_helper.ex` — Fixture load/save/replay helpers
+- `core/test/support/fixtures/` — Recorded fixture JSON files


### PR DESCRIPTION
Add five Claude Code agent skills for automated development workflows:
- git: enforce conventional commit messages (required for nx release)
- lint-and-format: run linters/formatters before committing
- codegen-sync: verify TS codegen stays in sync with Elixir types
- ci-preflight: run full CI checks locally before pushing
- live-tests: write live API tests and record fixture responses

Also add a SessionStart hook that installs pnpm and Elixir/Erlang
dependencies when running in Claude Code on the web.

https://claude.ai/code/session_01XvVJnAccVbDdqTV9migT7c